### PR TITLE
Added functionality for custom profile names I.E default 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ To install: \
 
 To use: \
 `ssocred {profile}`
+
+To set credentials to a custom profilename: \
+`ssocred {profile} {customProfile}`
+
+For instance when you want a default profile: \
+`ssocred {profile} default`
+
+You, can also set a custom profilename from any current profile that is not expired by running: \
+`ssocred {exsistinProfile} {customProfile}`

--- a/bin/index.js
+++ b/bin/index.js
@@ -6,7 +6,9 @@ const args = process.argv.splice(process.execArgv.length + 2)
 // Retrieve the first argument
 const profile = args[0]
 
+const customProfile = args[1] ? args[1] : undefined
+
 import SetCreds from "../lib/index.js"
 
 // Displays the text in the console
-SetCreds(profile)
+SetCreds(profile, customProfile)

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,11 @@ import path from "path"
 import AWS from "aws-sdk"
 import { spawn } from "child_process"
 
+const copyCred = (profiles, creds) => {
+    creds[profiles.customProfile] = creds[profiles.profile]
+    return writeCreds(creds)
+}
+
 const readConfig = () => {
     return ini.parse(
         readFileSync(path.resolve(homedir(), "./.aws/config"), "utf-8")
@@ -69,7 +74,13 @@ export default async (profile, customProfile) => {
             ? creds[profile].expiration
             : void 0) != null
     ) {
-        return creds[profile].expiration > Date.now()
+        if (
+            creds[profile].expiration > Date.now() &&
+            typeof customProfile != "undefined"
+        ) {
+            copyCred({ profile, customProfile }, creds)
+            return
+        }
     }
 
     const login = (profile) =>
@@ -119,19 +130,15 @@ export default async (profile, customProfile) => {
 
     return getCredentials(sso, params)
         .then(({ roleCredentials }) => {
-            if (typeof customProfile != "undefined") {
-                creds[customProfile] = {
-                    aws_access_key_id: roleCredentials.accessKeyId,
-                    aws_secret_access_key: roleCredentials.secretAccessKey,
-                    aws_session_token: roleCredentials.sessionToken,
-                    expiration: roleCredentials.expiration,
-                }
-            }
             creds[profile] = {
                 aws_access_key_id: roleCredentials.accessKeyId,
                 aws_secret_access_key: roleCredentials.secretAccessKey,
                 aws_session_token: roleCredentials.sessionToken,
                 expiration: roleCredentials.expiration,
+            }
+
+            if (typeof customProfile != "undefined") {
+                creds[customProfile] = creds[profile]
             }
 
             return writeCreds(creds)

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,7 @@ const getCredentials = (sso, params) => {
     return sso.getRoleCredentials(params).promise()
 }
 
-export default async (profile) => {
+export default async (profile, customProfile) => {
     const key = "profile " + profile
     const config = readConfig()
     if (typeof config[key] === "undefined") {
@@ -65,10 +65,11 @@ export default async (profile) => {
     const creds = readCreds()
 
     if (
-        creds[profile].expiration !== undefined &&
-        creds[profile].expiration > Date.now()
+        (typeof creds[profile] !== "undefined" && creds[profile] !== null
+            ? creds[profile].expiration
+            : void 0) != null
     ) {
-        return
+        return creds[profile].expiration > Date.now()
     }
 
     const login = (profile) =>
@@ -118,6 +119,14 @@ export default async (profile) => {
 
     return getCredentials(sso, params)
         .then(({ roleCredentials }) => {
+            if (typeof customProfile != "undefined") {
+                creds[customProfile] = {
+                    aws_access_key_id: roleCredentials.accessKeyId,
+                    aws_secret_access_key: roleCredentials.secretAccessKey,
+                    aws_session_token: roleCredentials.sessionToken,
+                    expiration: roleCredentials.expiration,
+                }
+            }
             creds[profile] = {
                 aws_access_key_id: roleCredentials.accessKeyId,
                 aws_secret_access_key: roleCredentials.secretAccessKey,


### PR DESCRIPTION
I'm lazy so writing the suffix "--profile myprofile" is a hassle.
With my changes you can add a second argument to create a profile with a custom name.

`ssocred {profile} {customProfile}`

If the profile isn't expired its just copies the profile credentials to the custom profile.

For future I'm thinking it would be nice to test the credentials and not only rely on  `expiration`.

This is my first PR for an open source project, so give me feedback if I've done something wrong. 